### PR TITLE
Allow to define references that should be exanded during fetch.

### DIFF
--- a/orders.json
+++ b/orders.json
@@ -72,6 +72,15 @@
                             "required": false,
                             "allowMultiple": false,
                             "dataType": "int"
+                        },
+                        {
+                            "name": "expand",
+                            "description": "References that should be expanded in orders",
+                            "paramType": "query",
+                            "defaultValue": "",
+                            "required": false,
+                            "allowMultiple": true,
+                            "dataType": "string"
                         }
                     ]
                 }


### PR DESCRIPTION
This change will allow to expand references defined in orders so that the full object information is returned instead of only the id of the referenced object. More details can be found at [SPHERE.IO's developer docu](http://dev.sphere.io/http-api.html#reference-expansion).

Example:

```
plain: ...?expand=shippingInfo.shippingMethod&expand=shippingInfo.shippingMethod.zoneRates[*].zone
encoded: ...?expand=shippingInfo.shippingMethod&expand=shippingInfo.shippingMethod.zoneRates%5B*%5D.zone
```
